### PR TITLE
Funcionalidades para manejar estructuras jerárquicas del IPC

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Rodrigo Chang and DIE-BG collaborators"]
 version = "0.5.0"
 
 [deps]
+AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 PrettyTables = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CPIDataBase"
 uuid = "bc2aee9a-d1f8-4cce-8750-9c1afc923989"
 authors = ["Rodrigo Chang and DIE-BG collaborators"]
-version = "0.5.0"
+version = "0.6.0"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/CPIDataBase.jl
+++ b/src/CPIDataBase.jl
@@ -54,7 +54,25 @@ module CPIDataBase
     export getdates
     include("utils/utils.jl")
 
-    
+    ##  ------------------------------------------------------------------------
+    #   Funcionalidades de árboles de cómputo del IPC
+    #   ------------------------------------------------------------------------
+    using AbstractTrees
+    import AbstractTrees: children, printnode
+    # Tipos básicos, un gasto básico y una estructura de grupo
+    export Item, Group 
+    # Funciones para construir a partir de estructura de códigos
+    export get_cpi_tree, cpi_tree_nodes 
+    # Operaciones básicas: 
+    # find_tree : Encontrar un nodo en el árbol con un código especificado
+    # compute_index : Computar el índice de cualquier nodo en el árbol con la fórmula del IPC
+    # compute_index! : Similar a compute_index pero utiliza una caché de diccionario
+    export find_tree, compute_index, compute_index!
+    export children, print_tree  # reexport from AbstractTrees
+
+    include("tree/CPItree.jl")
+
+
     ##  ------------------------------------------------------------------------
     #   Submódulo de pruebas
     #   ------------------------------------------------------------------------

--- a/src/helpers/test_helpers.jl
+++ b/src/helpers/test_helpers.jl
@@ -21,7 +21,12 @@ end
 
 
 """
-    getzerobase(T_type=Float32, G=218, T_periods=120, startdate=Date(2001,1), baseindex=100*one(T_type))
+    getzerobase(; 
+        [T_type = Float32, 
+        G = 218, 
+        T_periods = 120, 
+        startdate = Date(2001,1), 
+        baseindex = 100*one(T_type)])
 Función para obtener base de tipo `VarCPIBase` con variaciones intermensuales
 iguales a cero.
 """
@@ -32,19 +37,47 @@ function getzerobase(T_type=Float32, G=218, T_periods=120, startdate=Date(2001,1
     VarCPIBase(vmat, w, dates, baseindex)
 end
 
+function getzerobase(;
+    T_type = Float32, 
+    G = 218, 
+    T_periods = 120, 
+    startdate = Date(2001,1), 
+    baseindex = 100*one(T_type))
+
+    getzerobase(T_type, G, T_periods, startdate, baseindex)
+end
+
+
 """
-    getzerocountryst(T_type=Float32)
+    getzerocountryst(T_type = Float32)
 Obtiene un `UniformCountryStructure` cuyas variaciones intermensuales son todas
 iguales a cero en la configuración de períodos del IPC de Guatemala.
 """
-function getzerocountryst(T_type=Float32)
+function getzerocountryst(T_type = Float32)
     gt00 = getzerobase(T_type, 218, 120, Date(2001, 1))
     gt10 = getzerobase(T_type, 279, 120, Date(2011, 1))
     UniformCountryStructure(gt00, gt10)
 end
 
 """
-    getrandombase(T_type=Float32, G=218, T_periods=120, startdate=Date(2001,1), baseindex=100*one(T_type))
+    getrandomcountryst(T_type = Float32)
+Obtiene un `UniformCountryStructure` cuyas variaciones intermensuales son todas
+aleatorias en la configuración de períodos del IPC de Guatemala.
+"""
+function getrandomcountryst(T_type = Float32)
+    gt00 = getrandombase(T_type, 218, 120, Date(2001, 1))
+    gt10 = getrandombase(T_type, 279, 120, Date(2011, 1))
+    UniformCountryStructure(gt00, gt10)
+end
+
+
+"""
+    getrandombase(; 
+        [T_type = Float32, 
+        G = 218, 
+        T_periods = 120, 
+        startdate = Date(2001,1), 
+        baseindex = 100*one(T_type)])
 Función para obtener una base de tipo `VarCPIBase` con variaciones
 intermensuales aleatorias.
 """
@@ -53,4 +86,14 @@ function getrandombase(T_type=Float32, G=218, T_periods=120, startdate=Date(2001
     w = getrandomweights(T_type, G)
     dates = getbasedates(vmat, startdate)
     VarCPIBase(vmat, w, dates, baseindex)
+end
+
+function getrandombase(;
+    T_type = Float32, 
+    G = 218, 
+    T_periods = 120, 
+    startdate = Date(2001,1), 
+    baseindex = 100*one(T_type))
+
+    getrandombase(T_type, G, T_periods, startdate, baseindex)
 end

--- a/src/tree/CPItree.jl
+++ b/src/tree/CPItree.jl
@@ -1,0 +1,222 @@
+## CPItree.jl - Tipos y métodos para operar la estructura jerárquica del IPC
+
+##  ----------------------------------------------------------------------------
+#   Main type definitions
+#   ----------------------------------------------------------------------------
+
+abstract type AbstractNode{T<:AbstractFloat} end 
+
+struct Item{T} <: AbstractNode{T}
+    code::String
+    name::String
+    weight::T
+end
+
+struct Group{S,T} <: AbstractNode{T}
+    code::String
+    name::String
+    weight::T
+    children::Vector{S}
+
+    function Group(code, name, children...)
+        sum_weights = sum(child.weight for child in children)
+        T = eltype(sum_weights)
+        S = eltype(children)
+        new{S,T}(code, name, sum_weights, S[children...])
+    end
+    Group(code, name, children::Vector{S}) where {S} = Group(code, name, children...)
+end
+
+# Redefine methods for getting children
+children(::Item) = ()
+children(g::Group) = g.children
+
+# Redefine how to print a node in the print_tree function 
+printnode(io::IO, g::Item) = print(io, g.code * ": " * g.name * " [" * string(g.weight) * "] ")
+printnode(io::IO, g::Group) = print(io, g.code * ": " * g.name * " [" * string(g.weight) * "] ")
+
+# How to show a Group
+function Base.show(io::IO, g::Group)
+    println(io, typeof(g)) 
+    print_tree(io, g)
+end
+
+
+##  ----------------------------------------------------------------------------
+#   CPI tree functions 
+#   ----------------------------------------------------------------------------
+
+# Construye y devuelve una lista de nodos a partir de la lista de códigos
+# `codes` u de la especificación jerárquica de caracteres en `characters`. Los
+# nombres y las ponderaciones del nivel inferior (nivel de gasto básico) son
+# obtenidas de la estructura `full_base`. Se debe proveer el vector de códigos y
+# nombres de todas las jerarquías superiores en la estructura de códigos en los
+# vectores `group_names` y `group_codes`.
+function cpi_tree_nodes(codes::Vector{<:AbstractString}; 
+    characters::(NTuple{N, Int} where N), depth::Int=1, chars::Int=characters[depth], prefix::AbstractString="", 
+    full_base::FullCPIBase, 
+    group_names::Vector{<:AbstractString}, 
+    group_codes::Vector{<:AbstractString})
+    
+    # Get available starting codes 
+    available = filter(code -> startswith(code, prefix), codes)
+    
+    # Base case: 
+    # If code length is the last available then we reached a leaf node
+    if chars == last(characters)
+        # With available codes construct leaf CPI nodes
+        children = map(available) do code
+            # Find the code index 
+            icode = findfirst(==(code), codes)
+            Item(code, full_base.names[icode], full_base.w[icode])
+        end
+        return children
+    end
+
+    # Get possible prefixes values from the available list. Possible prefixes
+    # are the ones from the beginning of the string to the number of chars,
+    # which depends on the depth we are on.
+    possibles = unique(getindex.(available, Ref(1:chars)))
+
+    # For each available code, call the function itself with the next downward hierarchy
+    groups = map(possibles) do prefixcode
+        # Go get the children in the next downward level
+        children = cpi_tree_nodes(codes; 
+            characters, depth=depth+1, prefix=prefixcode,
+            full_base, group_names, group_codes
+        )
+        # Get the group name 
+        @debug "Prefix code:" prefixcode
+        gcode = findfirst(==(prefixcode), group_codes)
+        gcode === nothing && throw(ArgumentError("Código de grupo no encontrado en `group_codes`"))
+        gname = group_names[gcode]
+        # With the children create a group 
+        group = Group(prefixcode, gname, children)
+        group
+    end
+
+    # Return the group for the upward parents
+    return groups
+end
+
+# Función superior para obtener estructura jerárquica del IPC. Devuelve el nodo
+# superior del árbol jerárquico. Utiliza la función de más bajo nivel
+# `cpi_tree_nodes` para construir los nodos del nivel más alto y hacia abajo en
+# la estructura jerárquica. Se debe proveer el vector de códigos y nombres de
+# todas las jerarquías superiores en la estructura de códigos en los vectores
+# `group_names` y `group_codes`. 
+function get_cpi_tree(; 
+    full_base::FullCPIBase, 
+    group_names::Vector{<:AbstractString}, 
+    group_codes::Vector{<:AbstractString}, 
+    characters::(NTuple{N, Int} where N),
+    upperlevel_code = "_0", 
+    upperlevel_name = "IPC")
+
+    length(characters) >= 2 || throw(ArgumentError("`characters` debe ser una tupla con al menos dos valores"))
+    for i in 2:length(characters)
+        characters[i] > characters[i-1] || throw(ArgumentError("Valores en `characters` deben ser ascendentes hasta el largo de los códigos en full_base"))
+    end
+    # Get the codes list from the FullCPIBase object
+    codes = full_base.codes
+    @debug "Codes:" codes
+
+    # Call lower level tree building function
+    upper_nodes = cpi_tree_nodes(codes; characters, full_base, group_names, group_codes)
+    
+    # Build upper level tree node
+    tree = Group(upperlevel_code, upperlevel_name, upper_nodes)
+    tree
+end
+
+
+## Build functions to find the inner tree of a given code
+function find_tree(code, tree::Item) 
+    code == tree.code && return tree 
+    nothing
+end
+function find_tree(code, tree::Group)
+    # Most basic case: the code is the same as the tree in which to search 
+    code == tree.code && return tree
+
+    # Search in the tree's nodes 
+    for child in tree.children
+        # If code searched is one of the children, return the child
+        code == child.code && return child
+
+        # Look if the code starts the same as the child's code, i.e the code
+        # contains the child's code. If so, find in the inner tree and break out
+        # of this level's search
+        contains(code, child.code) && return find_tree(code, child)
+    end
+
+    # Code not found at any level
+    nothing
+end
+
+# Redefine getindex to search for specific nodes within the tree
+Base.getindex(tree::Group, code::AbstractString) = find_tree(code, tree)
+
+
+
+
+##  ----------------------------------------------------------------------------
+#   Functions to compute any code's price index from the lower level data
+#   ----------------------------------------------------------------------------
+
+# Basic case: compute index of an Item, which is stored in the `base` structure
+function compute_index(good::Item, base::FullCPIBase)
+    i = findfirst(==(good.code), base.codes)
+    base.ipc[:, i]
+end
+
+# Recursive function to compute inner price indexes for groups
+function compute_index(group, base::FullCPIBase)
+    # Get the indexes of the children. At the lowest level the dispatch will
+    # select compute_index(::Item, ::FullCPIBase) to return the Goods indices
+    ipcs = mapreduce(c -> compute_index(c, base), hcat, group.children)
+
+    # If there exists only one good in the group, that is the group's index
+    size(ipcs, 2) == 1 && return ipcs
+    
+    # Get the weights
+    weights = map(c -> c.weight, group.children) 
+
+    # Return normalized sum product 
+    ipcs * weights / sum(weights)
+end
+
+
+
+##  ----------------------------------------------------------------------------
+#   In-place functions to compute any code's price index from the lower level data
+#   ----------------------------------------------------------------------------
+
+function compute_index!(cache::Dict, good::Item, base::FullCPIBase)
+    i = findfirst(==(good.code), base.codes)
+    cache[good.code] = base.ipc[:, i] # save a copy in the cache
+    cache[good.code]
+end
+
+function compute_index!(cache::Dict, group::Group, base::FullCPIBase)
+    # If code is available in cache, just return it
+    group.code in keys(cache) && return cache[group.code]
+
+    # Else, compute the index and store it 
+    # Get the indexes of the children. At the lowest level the dispatch will
+    # select compute_index(::Item, ::FullCPIBase) to return the Goods indices
+    ipcs = mapreduce(c -> compute_index!(cache, c, base), hcat, group.children)
+
+    # If there exists only one good in the group, that is the group's index
+    if size(ipcs, 2) == 1 
+        cache[group.code] = ipcs 
+        return ipcs
+    end
+    
+    # Get the weights
+    weights = map(c -> c.weight, group.children) 
+
+    # Store normalized sum product 
+    cache[group.code] = ipcs * weights / sum(weights)
+    cache[group.code]
+end

--- a/test/cpitree.jl
+++ b/test/cpitree.jl
@@ -1,31 +1,24 @@
 using CPIDataGT
+using CSV, DataFrames
 using AbstractTrees
 import AbstractTrees: children, printnode
 
-# Read groups information 
-using CSV, DataFrames
-groupsdf = CSV.read(joinpath(pkgdir(CPIDataGT), "data", "Guatemala_IPC_2010_Groups.csv"), DataFrame)
-
-const GROUP_CODES = groupsdf[!, :Code]
-const GROUP_NAMES = groupsdf[!, :GroupName]
-
-struct Good{T<:AbstractFloat}
+struct Good
     code::String
     name::String
-    weight::T
+    weight::Union{Float32, Float64}
 end
 
-struct Group{S,T}
+struct Group{S}
     code::String
     name::String
-    weight::T
+    weight::Union{Float32, Float64}
     children::Vector{S}
 
     function Group(code, name, children...)
         sum_weights = sum(child.weight for child in children)
-        T = eltype(sum_weights)
         S = eltype(children)
-        new{S,T}(code, name, sum_weights, S[children...])
+        new{S}(code, name, sum_weights, S[children...])
     end
     Group(code, name, children::Vector{S}) where {S} = Group(code, name, children...)
 end
@@ -38,7 +31,8 @@ printnode(io::IO, g::Group) = print(io, g.code * ": " * g.name * " [" * string(g
 
 function Base.show(io::IO, g::Group)
     println(io, typeof(g)) 
-    print_tree(io, g)
+    # Show by default only the first depth level of the tree
+    print_tree(io, g, maxdepth=1)
 end
 
 g1 = Good(FGT10.codes[1], FGT10.names[1], FGT10.w[1])
@@ -53,51 +47,50 @@ foods = [Good(FGT10.codes[i], FGT10.names[i], FGT10.w[i]) for i in 1:74]
 foodiv = Group("_01", "Alimentos y bebidas no alcohólicas", foods)
 print_tree(foodiv)
 
-## Desarrollar la estructura recursiva
-CHARS = Dict(3 => 4, 4 => 5, 5 => 6, 6 => 8, 8 => 8)
 
-function mytree(codes, chars=3, prefix="")
+## CPI tree functions 
+
+# Construye y devuelve una lista de nodos a partir de la lista de códigos
+# `codes` u de la especificación jerárquica de caracteres en `characters`. Los
+# nombres y las ponderaciones del nivel inferior (nivel de gasto básico) son
+# obtenidas de la estructura `full_base`. Se debe proveer el vector de códigos y
+# nombres de todas las jerarquías superiores en la estructura de códigos en los
+# vectores `group_names` y `group_codes`.
+function cpi_tree_nodes(codes::Vector{<:AbstractString}; 
+    characters::(NTuple{N, Int} where N), depth::Int=1, chars::Int=characters[depth], prefix::AbstractString="", 
+    full_base::FullCPIBase, 
+    group_names::Vector{<:AbstractString}, 
+    group_codes::Vector{<:AbstractString})
     
     # Get available starting codes 
     available = filter(code -> startswith(code, prefix), codes)
     
-    if chars == 8
-        # Get available codes from prefix
-        # println("GB:", length(available))
-        # println(available)
-        # Good(FGT10.codes[1], FGT10.names[1], FGT10.w[1])
+    # Base case: 
+    # If code length is the last available then we reached a leaf node
+    if chars == last(characters)
+        # With available codes construct leaf CPI nodes
         children = map(available) do code
             # Find the code index 
             icode = findfirst(==(code), codes)
-            Good(code, FGT10.names[icode], FGT10.w[icode])
+            Good(code, full_base.names[icode], full_base.w[icode])
         end
-        # println(children)
         return children
     end
 
-    # Get possible prefixes values
+    # Get possible prefixes values from the available list. Possible prefixes
+    # are the ones from the beginning of the string to the number of chars,
+    # which depends on the depth we are on.
     possibles = unique(getindex.(available, Ref(1:chars)))
-    nextchars = CHARS[chars]
 
-    # For each available code, call the function itself with the next
-    # groups = []
-    # for prefixcode in possibles
-    #     # Print the prefix code 
-    #     # println(prefixcode)
-    #     # And go get the children 
-    #     children = mytree(codes, nextchars, prefixcode)
-    #     # With the children create a group 
-    #     group = Group(prefixcode, "GroupName", children)
-    #     # println(group)
-    #     push!(groups, group)
-    # end
-
+    # For each available code, call the function itself with the next downward hierarchy
     groups = map(possibles) do prefixcode
-        # Go get the children 
-        children = mytree(codes, nextchars, prefixcode)
+        # Go get the children in the next downward level
+        children = cpi_tree_nodes(codes; characters, depth=depth+1, prefix=prefixcode,
+            full_base, group_names, group_codes
+        )
         # Get the group name 
-        gcode = findfirst(==(prefixcode), GROUP_CODES)
-        gname = GROUP_NAMES[gcode]
+        gcode = findfirst(==(prefixcode), group_codes)
+        gname = group_names[gcode]
         # With the children create a group 
         group = Group(prefixcode, gname, children)
         group
@@ -107,6 +100,57 @@ function mytree(codes, chars=3, prefix="")
     return groups
 end
 
-cpidivs = mytree(FGT10.codes)
-cpi = Group("_0", "IPC", cpidivs)
-print_tree(cpi)
+# Función superior para obtener estructura jerárquica del IPC. Devuelve el nodo
+# superior del árbol jerárquico. Utiliza la función de más bajo nivel
+# `cpi_tree_nodes` para construir los nodos del nivel más alto y hacia abajo en
+# la estructura jerárquica. Se debe proveer el vector de códigos y nombres de
+# todas las jerarquías superiores en la estructura de códigos en los vectores
+# `group_names` y `group_codes`. 
+function get_cpi_tree(; 
+    full_base::FullCPIBase, 
+    group_names::Vector{<:AbstractString}, group_codes::Vector{<:AbstractString}, 
+    characters::(NTuple{N, Int} where N),
+    upperlevel_code = "_0", 
+    upperlevel_name = "IPC")
+
+    # Get the codes list from the FullCPIBase object
+    codes = full_base.codes
+
+    # Call lower level tree building function
+    upper_nodes = cpi_tree_nodes(codes; characters, full_base, group_names, group_codes)
+    
+    # Build upper level tree node
+    tree = Group(upperlevel_code, upperlevel_name, upper_nodes)
+    tree
+end
+
+
+
+
+## Building CPI Base 2010 tree
+
+groups10 = CSV.read(joinpath(pkgdir(CPIDataGT), "data", "Guatemala_IPC_2010_Groups.csv"), DataFrame)
+
+cpi_10_tree = get_cpi_tree(
+    full_base = FGT10, 
+    group_names = groups10[!, :GroupName], 
+    group_codes = groups10[!, :Code],
+    characters = (3,4,5,6,8) #(3, 8) #(3,4,5,6,8) 
+)
+
+cpi_10_tree
+print_tree(cpi_10_tree)
+
+## Building CPI Base 2000 tree
+groups00 = CSV.read(joinpath(pkgdir(CPIDataGT), "data", "Guatemala_IPC_2000_Groups.csv"), DataFrame)
+
+cpi_00_tree = get_cpi_tree(
+    full_base = FGT00, 
+    group_names = groups00[!, :GroupName], 
+    group_codes = groups00[!, :Code],
+    characters = (3, 7)
+)
+
+cpi_00_tree
+print_tree(cpi_00_tree)
+

--- a/test/cpitree.jl
+++ b/test/cpitree.jl
@@ -1,0 +1,112 @@
+using CPIDataGT
+using AbstractTrees
+import AbstractTrees: children, printnode
+
+# Read groups information 
+using CSV, DataFrames
+groupsdf = CSV.read(joinpath(pkgdir(CPIDataGT), "data", "Guatemala_IPC_2010_Groups.csv"), DataFrame)
+
+const GROUP_CODES = groupsdf[!, :Code]
+const GROUP_NAMES = groupsdf[!, :GroupName]
+
+struct Good{T<:AbstractFloat}
+    code::String
+    name::String
+    weight::T
+end
+
+struct Group{S,T}
+    code::String
+    name::String
+    weight::T
+    children::Vector{S}
+
+    function Group(code, name, children...)
+        sum_weights = sum(child.weight for child in children)
+        T = eltype(sum_weights)
+        S = eltype(children)
+        new{S,T}(code, name, sum_weights, S[children...])
+    end
+    Group(code, name, children::Vector{S}) where {S} = Group(code, name, children...)
+end
+
+children(::Good) = ()
+children(g::Group) = g.children
+
+printnode(io::IO, g::Good) = print(io, g.code * ": " * g.name * " [" * string(g.weight) * "] ")
+printnode(io::IO, g::Group) = print(io, g.code * ": " * g.name * " [" * string(g.weight) * "] ")
+
+function Base.show(io::IO, g::Group)
+    println(io, typeof(g)) 
+    print_tree(io, g)
+end
+
+g1 = Good(FGT10.codes[1], FGT10.names[1], FGT10.w[1])
+g2 = Good(FGT10.codes[2], FGT10.names[2], FGT10.w[2])
+
+gr1 = Group("_01", "Alimentos y bebidas no alcohólicas", [g1, g2])
+gr1 = Group("_01", "Alimentos y bebidas no alcohólicas", g1, g2)
+
+print_tree(gr1)
+
+foods = [Good(FGT10.codes[i], FGT10.names[i], FGT10.w[i]) for i in 1:74]
+foodiv = Group("_01", "Alimentos y bebidas no alcohólicas", foods)
+print_tree(foodiv)
+
+## Desarrollar la estructura recursiva
+CHARS = Dict(3 => 4, 4 => 5, 5 => 6, 6 => 8, 8 => 8)
+
+function mytree(codes, chars=3, prefix="")
+    
+    # Get available starting codes 
+    available = filter(code -> startswith(code, prefix), codes)
+    
+    if chars == 8
+        # Get available codes from prefix
+        # println("GB:", length(available))
+        # println(available)
+        # Good(FGT10.codes[1], FGT10.names[1], FGT10.w[1])
+        children = map(available) do code
+            # Find the code index 
+            icode = findfirst(==(code), codes)
+            Good(code, FGT10.names[icode], FGT10.w[icode])
+        end
+        # println(children)
+        return children
+    end
+
+    # Get possible prefixes values
+    possibles = unique(getindex.(available, Ref(1:chars)))
+    nextchars = CHARS[chars]
+
+    # For each available code, call the function itself with the next
+    # groups = []
+    # for prefixcode in possibles
+    #     # Print the prefix code 
+    #     # println(prefixcode)
+    #     # And go get the children 
+    #     children = mytree(codes, nextchars, prefixcode)
+    #     # With the children create a group 
+    #     group = Group(prefixcode, "GroupName", children)
+    #     # println(group)
+    #     push!(groups, group)
+    # end
+
+    groups = map(possibles) do prefixcode
+        # Go get the children 
+        children = mytree(codes, nextchars, prefixcode)
+        # Get the group name 
+        gcode = findfirst(==(prefixcode), GROUP_CODES)
+        gname = GROUP_NAMES[gcode]
+        # With the children create a group 
+        group = Group(prefixcode, gname, children)
+        group
+    end
+
+    # Return the group for the upward parents
+    return groups
+end
+
+cpidivs = mytree(FGT10.codes)
+cpi = Group("_0", "IPC", cpidivs)
+print_tree(cpi)

--- a/test/create_types.jl
+++ b/test/create_types.jl
@@ -1,0 +1,87 @@
+@testset "Create types" begin
+
+    GB = 10
+    PER = 20
+    baseindex = 100.0
+    
+    v = rand(PER, GB) .- 0.25
+    ipc = capitalize(v, baseindex)
+    w = rand(GB)
+
+    basedate = Date(2010,12)
+    enddate = basedate + Month(PER-1)
+    dates = basedate:Month(1):enddate
+
+    ## Create individual types with same arrays: FullCPIBase, VarCPIBase, IndexCPIBase
+    fullcpi = FullCPIBase(ipc, v, w, dates, baseindex)
+    vcpi = VarCPIBase(v, w, dates, baseindex)
+    indexcpi = IndexCPIBase(ipc, w, dates, baseindex)
+
+    # Test they share the same arrays
+    @test fullcpi.ipc === indexcpi.ipc
+    @test fullcpi.v === vcpi.v
+    @test fullcpi.w === vcpi.w === indexcpi.w
+    
+    # Create copies with constructors from FullCPIBase and test they hold different arrays
+    vcpi2 = VarCPIBase(fullcpi)
+    indexcpi2 = IndexCPIBase(fullcpi)
+
+    @test vcpi.v == vcpi2.v     # same values in matrix
+    @test !(vcpi.v === vcpi2.v) # different reference in memory
+
+    @test indexcpi.ipc == indexcpi2.ipc
+    @test !(indexcpi.ipc === indexcpi2.ipc)
+
+    @test vcpi.dates == vcpi2.dates
+    @test indexcpi.dates == indexcpi2.dates
+
+
+    ## Test convert methods with different precision floats
+    fullcpi32 = convert(Float32, deepcopy(fullcpi))
+    vcpi32 = convert(Float32, deepcopy(vcpi))
+    indexcpi32 = convert(Float32, deepcopy(indexcpi))
+    
+    # as matrixs are different type, == does not apply, check with isapprox
+    @test fullcpi32.ipc ≈ fullcpi.ipc   
+    @test fullcpi32.v == vcpi32.v
+
+    @test indexcpi32.ipc ≈ indexcpi.ipc
+    @test fullcpi32.ipc == indexcpi32.ipc
+    
+    @test vcpi32.v ≈ vcpi.v
+    @test fullcpi32.baseindex == vcpi32.baseindex == indexcpi32.baseindex
+
+    
+    ## Create types with different base indexes
+    baseindex = rand(100:0.5:110, GB)
+
+    fullcpi_b = FullCPIBase(ipc, v, w, dates, baseindex)
+    vcpi_b = VarCPIBase(fullcpi_b)
+    indexcpi_b = IndexCPIBase(vcpi_b)
+
+    # Test they hold the same base indexes, but not same arrays
+    @test vcpi_b.baseindex == indexcpi_b.baseindex
+    @test !(vcpi_b.baseindex === indexcpi_b.baseindex)
+    @test length(fullcpi_b.baseindex) > 1
+    @test length(vcpi_b.baseindex) > 1
+    @test length(indexcpi_b.baseindex) > 1
+
+
+    ## Create CountryStructure 
+
+    # These hold the same v array values (not same array objects) with different base indexes
+    cs = MixedCountryStructure((vcpi, vcpi_b))
+
+    @test cs[1].v == cs[2].v
+    @test !(cs[1].v === cs[2].v)
+    @test typeof(cs[1].baseindex) != typeof(cs[2].baseindex) # different containers
+    @test eltype(cs[1].baseindex) == eltype(cs[2].baseindex) # same types
+    @test length(cs[1].baseindex) != length(cs[2].baseindex) # different length
+
+    # Check conversion of precision types
+    cs32 = convert(Float32, cs)
+    
+    @test cs32[1].v ≈ cs[1].v
+    @test eltype(cs32[1].baseindex) == Float32
+
+end

--- a/test/inflation.jl
+++ b/test/inflation.jl
@@ -1,0 +1,45 @@
+@testset "Inflation with MixedCountryStructure" begin
+    
+    GB = 200
+    PER = 120
+    baseindex = rand(100:0.5:110, GB)
+    
+    v = rand(PER, GB) .- 0.25
+    w = rand(GB)
+    w = w / sum(w)
+
+    basedate = Date(2001,1)
+    dates = getdates(basedate, PER)
+
+    # Base with different base indexes per product
+    vcpi_mixed = VarCPIBase(v, w, dates, baseindex)
+    mcs = MixedCountryStructure(vcpi_mixed)
+
+    # Basic inflation function test
+    totalfn = InflationTotalCPI() 
+    @test totalfn(mcs) isa Vector
+    @test infl_periods(mcs) == (PER-11)
+
+    # Mix with base with same base index
+    GB = 315
+    PER = 120
+    baseindex = 100.0
+
+    v2 = rand(PER, GB) .- 0.25
+    w2 = rand(GB)
+    w2 = w2 / sum(w)
+
+    basedate = Date(2011,1)
+    dates2 = getdates(basedate, PER)
+
+    vcpi_uniform = VarCPIBase(v2, w2, dates2, baseindex)
+    mcs = MixedCountryStructure(vcpi_mixed, vcpi_uniform)
+
+    @test totalfn(mcs) isa Vector
+    @test infl_periods(mcs) == (240-11)
+
+    # Test indexing
+    @test mcs[1] == vcpi_mixed
+    @test mcs[2] == vcpi_uniform
+
+end

--- a/test/operations.jl
+++ b/test/operations.jl
@@ -1,0 +1,32 @@
+@testset "Operations with types" begin 
+
+    using CPIDataBase
+    S = 10
+    v = zeros(S, S)
+
+    ## Test capitalize
+    @test :capitalize in names(CPIDataBase)
+
+    # Test capitalization with default base index
+    cap = capitalize(v)
+    @test all(cap .== 100)
+
+    # Test capitalization with different base index
+    @test all(capitalize(v, 110) .== 110)
+
+    base_idx = rand(100:110, S)
+    cap = capitalize(v, base_idx)
+    @test all(100 .<= cap[1, :] .<= 110)
+    
+    # Test capitalize_addbase
+    cap = CPIDataBase.capitalize_addbase(v, base_idx)
+    @test all(100 .<= cap[1, :] .<= 110)
+    @test size(cap, 1) == size(v, 1)+1
+
+    ## Test varinterm 
+    # TODO
+    
+    ## Test varinteran
+    # TODO
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,174 +1,19 @@
 using CPIDataBase, Dates
 using CPIDataBase.TestHelpers
+using DataFrames
 using Test
 
-@testset "Create types" begin
+# Creation of types
+include("create_types.jl")
 
-    GB = 10
-    PER = 20
-    baseindex = 100.0
-    
-    v = rand(PER, GB) .- 0.25
-    ipc = capitalize(v, baseindex)
-    w = rand(GB)
+# Test some VarCPIBase and CountryStructure operations
+include("operations.jl")
 
-    basedate = Date(2010,12)
-    enddate = basedate + Month(PER-1)
-    dates = basedate:Month(1):enddate
+# Inflation tests with MixedCountryStructure
+include("inflation.jl")
 
-    ## Create individual types with same arrays: FullCPIBase, VarCPIBase, IndexCPIBase
-    fullcpi = FullCPIBase(ipc, v, w, dates, baseindex)
-    vcpi = VarCPIBase(v, w, dates, baseindex)
-    indexcpi = IndexCPIBase(ipc, w, dates, baseindex)
-
-    # Test they share the same arrays
-    @test fullcpi.ipc === indexcpi.ipc
-    @test fullcpi.v === vcpi.v
-    @test fullcpi.w === vcpi.w === indexcpi.w
-    
-    # Create copies with constructors from FullCPIBase and test they hold different arrays
-    vcpi2 = VarCPIBase(fullcpi)
-    indexcpi2 = IndexCPIBase(fullcpi)
-
-    @test vcpi.v == vcpi2.v     # same values in matrix
-    @test !(vcpi.v === vcpi2.v) # different reference in memory
-
-    @test indexcpi.ipc == indexcpi2.ipc
-    @test !(indexcpi.ipc === indexcpi2.ipc)
-
-    @test vcpi.dates == vcpi2.dates
-    @test indexcpi.dates == indexcpi2.dates
-
-
-    ## Test convert methods with different precision floats
-    fullcpi32 = convert(Float32, deepcopy(fullcpi))
-    vcpi32 = convert(Float32, deepcopy(vcpi))
-    indexcpi32 = convert(Float32, deepcopy(indexcpi))
-    
-    # as matrixs are different type, == does not apply, check with isapprox
-    @test fullcpi32.ipc ≈ fullcpi.ipc   
-    @test fullcpi32.v == vcpi32.v
-
-    @test indexcpi32.ipc ≈ indexcpi.ipc
-    @test fullcpi32.ipc == indexcpi32.ipc
-    
-    @test vcpi32.v ≈ vcpi.v
-    @test fullcpi32.baseindex == vcpi32.baseindex == indexcpi32.baseindex
-
-    
-    ## Create types with different base indexes
-    baseindex = rand(100:0.5:110, GB)
-
-    fullcpi_b = FullCPIBase(ipc, v, w, dates, baseindex)
-    vcpi_b = VarCPIBase(fullcpi_b)
-    indexcpi_b = IndexCPIBase(vcpi_b)
-
-    # Test they hold the same base indexes, but not same arrays
-    @test vcpi_b.baseindex == indexcpi_b.baseindex
-    @test !(vcpi_b.baseindex === indexcpi_b.baseindex)
-    @test length(fullcpi_b.baseindex) > 1
-    @test length(vcpi_b.baseindex) > 1
-    @test length(indexcpi_b.baseindex) > 1
-
-
-    ## Create CountryStructure 
-
-    # These hold the same v array values (not same array objects) with different base indexes
-    cs = MixedCountryStructure((vcpi, vcpi_b))
-
-    @test cs[1].v == cs[2].v
-    @test !(cs[1].v === cs[2].v)
-    @test typeof(cs[1].baseindex) != typeof(cs[2].baseindex) # different containers
-    @test eltype(cs[1].baseindex) == eltype(cs[2].baseindex) # same types
-    @test length(cs[1].baseindex) != length(cs[2].baseindex) # different length
-
-    # Check conversion of precision types
-    cs32 = convert(Float32, cs)
-    
-    @test cs32[1].v ≈ cs[1].v
-    @test eltype(cs32[1].baseindex) == Float32
-
-end
-
-@testset "Operations with types" begin 
-
-    using CPIDataBase
-    S = 10
-    v = zeros(S, S)
-
-    ## Test capitalize
-    @test :capitalize in names(CPIDataBase)
-
-    # Test capitalization with default base index
-    cap = capitalize(v)
-    @test all(cap .== 100)
-
-    # Test capitalization with different base index
-    @test all(capitalize(v, 110) .== 110)
-
-    base_idx = rand(100:110, S)
-    cap = capitalize(v, base_idx)
-    @test all(100 .<= cap[1, :] .<= 110)
-    
-    # Test capitalize_addbase
-    cap = CPIDataBase.capitalize_addbase(v, base_idx)
-    @test all(100 .<= cap[1, :] .<= 110)
-    @test size(cap, 1) == size(v, 1)+1
-
-    ## Test varinterm 
-    # TODO
-    
-    ## Test varinteran
-    # TODO
-
-end
-
-
-@testset "Inflation with MixedCountryStructure" begin
-    
-    GB = 200
-    PER = 120
-    baseindex = rand(100:0.5:110, GB)
-    
-    v = rand(PER, GB) .- 0.25
-    w = rand(GB)
-    w = w / sum(w)
-
-    basedate = Date(2001,1)
-    dates = getdates(basedate, PER)
-
-    # Base with different base indexes per product
-    vcpi_mixed = VarCPIBase(v, w, dates, baseindex)
-    mcs = MixedCountryStructure(vcpi_mixed)
-
-    # Basic inflation function test
-    totalfn = InflationTotalCPI() 
-    @test totalfn(mcs) isa Vector
-    @test infl_periods(mcs) == (PER-11)
-
-    # Mix with base with same base index
-    GB = 315
-    PER = 120
-    baseindex = 100.0
-
-    v2 = rand(PER, GB) .- 0.25
-    w2 = rand(GB)
-    w2 = w2 / sum(w)
-
-    basedate = Date(2011,1)
-    dates2 = getdates(basedate, PER)
-
-    vcpi_uniform = VarCPIBase(v2, w2, dates2, baseindex)
-    mcs = MixedCountryStructure(vcpi_mixed, vcpi_uniform)
-
-    @test totalfn(mcs) isa Vector
-    @test infl_periods(mcs) == (240-11)
-
-    # Test indexing
-    @test mcs[1] == vcpi_mixed
-    @test mcs[2] == vcpi_uniform
-
-end
+# Trees creation and operations 
+include("cpitree.jl")
 
 
 # # @testset "Inflation values and dates with disjoint VarCPIBase objects" begin 


### PR DESCRIPTION
- Se crean nuevos tipos Item y Group para manejar estructuras jerárquicas del IPC.
- Función para construcción automática del árbol jerárquico a partir de los códigos de una base del IPC. 
- Se agregan operaciones de búsqueda de nodos y cómputo de índices de cualquier nodo. 
- Reorganización de pruebas del paquete. 